### PR TITLE
Make `git remote |` example work

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ program.complete({
 
 program.complete({
   // `git remote |`
-  line: 'git remote',
+  line: 'git remote ',
   cursor: 11
 }, function (err, results) {
   results; // ['add', 'remove']


### PR DESCRIPTION
I think there needs to be a space added to the "git remote" line in the git example.

This is the behavior I'm seeing:

Current (without a space):

```
program.complete({
  line: 'git remote',
  cursor: 11
}, function (err, results) {
  results; // ['remote']
});
```

New (with a space):

```
program.complete({
  line: 'git remote ',
  cursor: 11
}, function (err, results) {
  results; // ['add', 'remove']
});
```